### PR TITLE
Auto-generate output filename and path in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,16 @@ from py_aas_submodels.nameplate_02006_2_0 import Nameplate
 
 ```bash
 pip install aas-submodel-to-py
-submodel_to_code -i template.aasx -o output.py
+
+# Minimal: output .py is generated next to the input file
+# e.g. IDTA-02006-2-0_Submodel_Digital Nameplate.aasx → IDTA_02006_2_0_Submodel_Digital_Nameplate.py
+submodel_to_code -i /some/path/DigitalNameplate.aasx
+
+# OR write to a specific output directory (filename still auto-derived)
+submodel_to_code -i /some/path/DigitalNameplate.aasx -d /some/other/path/
+
+# OR write to an explicit output file path
+submodel_to_code -i /some/path/DigitalNameplate.aasx -o /some/path/output.py
 ```
 
 ## Repository Structure

--- a/aas-submodel-to-py/README.md
+++ b/aas-submodel-to-py/README.md
@@ -101,23 +101,28 @@ pip install -e ./aas-submodel-to-py
 ### Command Line
 
 ```bash
-# Specify the output file explicitly
+# Minimal: output .py is generated next to the input file
+# e.g. IDTA-02006-2-0_Submodel_Digital Nameplate.aasx → IDTA_02006_2_0_Submodel_Digital_Nameplate.py
+submodel_to_code -i /some/path/DigitalNameplate.aasx
+
+# Write to a specific output directory (filename still auto-derived)
+submodel_to_code -i /some/path/DigitalNameplate.aasx -d /some/other/path/
+
+# Write to an explicit output file path
 submodel_to_code -i /some/path/DigitalNameplate.aasx -o /some/path/output.py
 
-# Let the filename be derived from the input (hyphens/spaces → underscores)
-# e.g. IDTA-02006-2-0_Submodel_Digital Nameplate.aasx → IDTA_02006_2_0_Submodel_Digital_Nameplate.py
-submodel_to_code -i /some/path/DigitalNameplate.aasx -d /some/path/
-
 # Overwrite an existing output file
-submodel_to_code -i /some/path/DigitalNameplate.aasx -o /some/path/output.py --force
+submodel_to_code -i /some/path/DigitalNameplate.aasx --force
 ```
 
 | Flag | Long form | Description | Required |
 |---|---|---|---|
 | `-i` | `--aas_path` | Input AAS file (`.aasx`, `.json`, or `.xml`) | Yes |
-| `-o` | `--outpath` | Output `.py` file path (mutually exclusive with `-d`) | One of `-o`/`-d` |
-| `-d` | `--outdir` | Output directory; filename is derived from the input filename (mutually exclusive with `-o`) | One of `-o`/`-d` |
+| `-o` | `--outpath` | Output `.py` file path (mutually exclusive with `-d`) | No |
+| `-d` | `--outdir` | Output directory; filename is derived from the input filename (mutually exclusive with `-o`) | No |
 | `-f` | `--force` | Overwrite the output file if it already exists | No |
+
+If neither `-o` nor `-d` is given, the output file is written next to the input file with hyphens and spaces in the name replaced by underscores.
 
 If the entry-point is not on PATH, use the module invocation:
 

--- a/aas-submodel-to-py/aas_submodel_to_py/submodel_to_code.py
+++ b/aas-submodel-to-py/aas_submodel_to_py/submodel_to_code.py
@@ -16,7 +16,7 @@ def main() -> None:
     """Execute the main routine."""
     parser = argparse.ArgumentParser("Reads a correct file with submodels and produces python submodel-specific classes")
     parser.add_argument("-i", "--aas_path", help="path to the file with submodel/-s (AASX, JSON or XML)", required=True)
-    out_group = parser.add_mutually_exclusive_group(required=True)
+    out_group = parser.add_mutually_exclusive_group(required=False)
     out_group.add_argument("-o", "--outpath", help="path to the output file")
     out_group.add_argument("-d", "--outdir", help="output directory; filename is derived from the input filename")
     parser.add_argument("-f", "--force", help="overwrite existing files", action="store_true")
@@ -25,8 +25,10 @@ def main() -> None:
     aas_path = pathlib.Path(args.aas_path)
     if args.outpath:
         out_path = pathlib.Path(args.outpath)
-    else:
+    elif args.outdir:
         out_path = pathlib.Path(args.outdir) / _auto_filename(aas_path)
+    else:
+        out_path = aas_path.parent / _auto_filename(aas_path)
     force = bool(args.force)
 
     if not aas_path.exists():


### PR DESCRIPTION
## Summary

- The CLI now auto-derives the output `.py` filename from the input file stem, replacing hyphens and spaces with underscores (e.g. `IDTA-02006-2-0_Submodel_Digital Nameplate.aasx` → `IDTA_02006_2_0_Submodel_Digital_Nameplate.py`)
- When neither `-o` nor `-d` is specified, the output file is written next to the input file — no output argument needed at all
- `-d`/`--outdir` option added as an alternative to `-o`/`--outpath` for specifying just the output directory; the two flags are mutually exclusive
- READMEs updated accordingly

**Before:**
```bash
submodel_to_code -i template.aasx -o output.py  # -o was required
```

**After:**
```bash
submodel_to_code -i template.aasx               # output placed next to input
submodel_to_code -i template.aasx -d /out/dir/  # output in chosen directory
submodel_to_code -i template.aasx -o custom.py  # explicit path still works
```